### PR TITLE
feat(space-zero): Set margin/padding spaces to zero

### DIFF
--- a/src/objects/_spacing.scss
+++ b/src/objects/_spacing.scss
@@ -10,6 +10,7 @@
 // The available directions are `top`, `bottom`, `left`, `right`, `vertical`, `horizontal`.
 // The available sizes ranges from `xs` to `xl`.
 // The default class `sb-margin` adds the medium sized margin to all sides.
+// The `zero` suffix removes the margin by setting them to 0
 //
 // Markup:
 // <div class="sb-tile sb-margin-bottom-xs sb-padding">
@@ -30,9 +31,13 @@
 //
 // Styleguide spacing.margins
 
-$sb-spacing-map: ('-xs': 7px, '-s': 11px, '': 16px, '-l': 23px, '-xl': 40px);
+$sb-spacing-map: ('-xs': 7px, '-s': 11px, '': 16px, '-l': 23px, '-xl': 40px, '-zero': 0);
 
 @each $suffix, $spacing in $sb-spacing-map {
+  .#{$ns}margin#{$suffix} {
+    margin: sb-px2rems($spacing);
+  }
+
   .#{$ns}margin-top#{$suffix} {
     margin-top: sb-px2rems($spacing);
   }
@@ -58,10 +63,6 @@ $sb-spacing-map: ('-xs': 7px, '-s': 11px, '': 16px, '-l': 23px, '-xl': 40px);
     margin-top: sb-px2rems($spacing);
     margin-bottom: sb-px2rems($spacing);
   }
-
-  .#{$ns}margin#{$suffix} {
-    margin: sb-px2rems($spacing);
-  }
 }
 
 // Paddings
@@ -70,6 +71,7 @@ $sb-spacing-map: ('-xs': 7px, '-s': 11px, '': 16px, '-l': 23px, '-xl': 40px);
 // The available directions are `top`, `bottom`, `left`, `right`, `vertical`, `horizontal`.
 // The available sizes ranges from `xs` to `xl`.
 // The default class `sb-padding` adds the medium sized padding to all sides.
+// The `zero` suffix removes the padding by setting them to 0
 //
 // Markup:
 // <div class="sb-tile  sb-padding-xs sb-margin-bottom">
@@ -91,6 +93,10 @@ $sb-spacing-map: ('-xs': 7px, '-s': 11px, '': 16px, '-l': 23px, '-xl': 40px);
 // Styleguide spacing.paddings
 
 @each $suffix, $spacing in $sb-spacing-map {
+  .#{$ns}padding#{$suffix} {
+    padding: sb-px2rems($spacing);
+  }
+
   .#{$ns}padding-top#{$suffix} {
     padding-top: sb-px2rems($spacing);
   }
@@ -115,9 +121,5 @@ $sb-spacing-map: ('-xs': 7px, '-s': 11px, '': 16px, '-l': 23px, '-xl': 40px);
   .#{$ns}padding-vertical#{$suffix} {
     padding-top: sb-px2rems($spacing);
     padding-bottom: sb-px2rems($spacing);
-  }
-
-  .#{$ns}padding#{$suffix} {
-    padding: sb-px2rems($spacing);
   }
 }

--- a/src/tools/_functions.scss
+++ b/src/tools/_functions.scss
@@ -8,7 +8,13 @@
 @function sb-px2rems($px) {
   $base-font-size: 16px;
 
-  @return ($px / $base-font-size) * 1rem;
+  @if $px == 0 {
+    @return 0;
+  }
+
+  @else {
+    @return ($px / $base-font-size) * 1rem;
+  }
 }
 
 @mixin sb-clearfix() {


### PR DESCRIPTION
Reviewers @dine @piet @spirosikmd @tzengerink

### What
We have different ways to add a margin/padding to an element via a class, but we don't have any way to remove them.
Unfortunately none of the core team members of stylabilla are here to validate it, but I think it's a pretty straightforward concept and safe to add.

### Why
I mostly need it - right now - to remove the gutters from a grid container, which is a much more complex undertaking and I know there are plans already to rework the grid as it's not good enough.

I like the suffix zero as it's immediately meaningful but maybe you have other suggestions?

### Notes for testing
- px2rem has to check if 0 or the linter will complain