### PR TITLE
feat(grid): add more options to grid

### DIFF
--- a/src/components/_header.scss
+++ b/src/components/_header.scss
@@ -59,7 +59,7 @@
   }
 }
 
-@include breakpoint-l {
+@include breakpoint-m {
   .#{$ns}header__content {
     flex-direction: row;
     align-items: baseline;

--- a/src/components/_toast.scss
+++ b/src/components/_toast.scss
@@ -101,7 +101,7 @@
   }
 }
 
-@include breakpoint-l {
+@include breakpoint-m {
   .#{$ns}toast {
     max-width: 40%;
 

--- a/src/objects/_grid.scss
+++ b/src/objects/_grid.scss
@@ -6,175 +6,193 @@
 //
 // Markup:
 // <div class="sb-grid">
-//   <div class="sb-tile sb-padding sb-col-4">
+//   <div class="sb-tile sb-col-4">
 //     .sb-col-4
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-4">
+//   <div class="sb-tile sb-col-4">
 //     .sb-col-4
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-4">
+//   <div class="sb-tile sb-col-4">
 //     .sb-col-4
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-4">
+//   <div class="sb-tile sb-col-4">
 //     .sb-col-4
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-4">
+//   <div class="sb-tile sb-col-4">
 //     .sb-col-4
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-4">
+//   <div class="sb-tile sb-col-4">
 //     .sb-col-4
 //   </div>
 // </div>
 //
 // Styleguide grid
 
+$grid-columns: 12 !default;
+$grid-gutter-width: 23px !default;
+
 .#{$ns}grid {
-  display: flex;
-  flex-wrap: wrap;
+  @include make-row;
 }
 
 // Containers
 //
-// Two container classes. All page containers should use `sb-container` which is set to a max-width of 1920px. You can also use `sb-container-fluid` for full width containers.
+// Two container classes. All page containers should use `sb-container` will have a max-width based on viewport. <br />
+// You can also use `sb-container-fluid` for full width containers.
 //
 // Markup:
-// <div class="sb-container sb-tile sb-padding">
+// <div class="sb-container sb-tile">
 //   .sb-container
 // </div>
-// <div class="sb-container-fluid sb-tile sb-padding">
+// <div class="sb-container-fluid sb-tile">
 //   .sb-container-fluid
 // </div>
 //
 // Styleguide grid.containers
 
+$sb-container-s: (720px + $grid-gutter-width) !default;
+$sb-container-m: (920px + $grid-gutter-width) !default;
+$sb-container-l: (1900px + $grid-gutter-width) !default; // previous $sb-container (1920px)
+
 .#{$ns}container {
-  max-width: sb-px2rems($sb-container);
-  width: 100%;
+  @include container-fixed;
+
+  @media (min-width: $sb-breakpoint-s) {
+    max-width: $sb-container-s;
+  }
+
+  @media (min-width: $sb-breakpoint-m) {
+    max-width: $sb-container-m;
+  }
+
+  @media (min-width: $sb-breakpoint-l) {
+    max-width: $sb-container-l;
+  }
 }
 
 .#{$ns}container-fluid {
-  width: 100%;
+  @include container-fixed;
 }
 
 // Columns
 //
 // Column classes. Use `sb-col-#{i}` to set the desired column width.
+// The columns will use the medium viewport as a breakpoint.
 //
 // Markup:
 // <div class="sb-grid">
-//   <div class="sb-tile sb-padding sb-col-12">
+//   <div class="sb-tile sb-col-12">
 //     .sb-col-12
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-10">
+//   <div class="sb-tile sb-col-10">
 //     .sb-col-10
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-2">
+//   <div class="sb-tile sb-col-2">
 //     .sb-col-2
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-9">
+//   <div class="sb-tile sb-col-9">
 //     .sb-col-9
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-3">
+//   <div class="sb-tile sb-col-3">
 //     .sb-col-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-8">
+//   <div class="sb-tile sb-col-8">
 //     .sb-col-8
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-4">
+//   <div class="sb-tile sb-col-4">
 //     .sb-col-4
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-7">
+//   <div class="sb-tile sb-col-7">
 //     .sb-col-7
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-5">
+//   <div class="sb-tile sb-col-5">
 //     .sb-col-5
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-6">
+//   <div class="sb-tile sb-col-6">
 //     .sb-col-6
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-6">
+//   <div class="sb-tile sb-col-6">
 //     .sb-col-6
 //   </div>
 // </div>
 //
 // Styleguide grid.columns
 
-$grid-columns: 12;
-$gutter-width: sb-px2rems(20px);
-
-@mixin sb-grid-item($grid-item-number) {
-  flex-shrink: 0;
-  flex-grow: 1;
-  flex-basis: calc(((100% / #{$grid-columns}) * #{$grid-item-number}) - #{$gutter-width});
-  margin: calc(#{$gutter-width} / 2);
-}
-
-@for $i from 1 through $grid-columns {
-  .#{$ns}col-#{$i} {
-    @include sb-grid-item(#{$i});
-  }
-}
+@include make-grid-columns;
 
 // Responsive Grid
 //
 // To create a responsive grid you can add different column classes for different viewports. <br/>
 // Add a `sb-col-s-#{i}` to set the desired column width for smaller viewports. <br/>
+// Add a `sb-col-m-#{i}` to set the desired column width for medium viewports. <br/>
 // Add a `sb-col-l-#{i}` to set the desired column width for larger viewports.
+// Note: Using `sb-col-#{i}` will behave the same as using `sb-col-m-#{i}`. <br/>
 //
 // Markup:
 // <div class="sb-grid">
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-s-12 sb-col-4 sb-col-l-3">
+//   <div class="sb-tile sb-col-s-12 sb-col-4 sb-col-l-3">
 //     .sb-col-s-12 .sb-col-4 .sb-col-l-3
 //   </div>
 // </div>
 //
 // Styleguide grid.responsive
 
-@for $i from 1 through $grid-columns {
-  @media (max-width: $sb-breakpoint-s) {
-    .#{$ns}col-s-#{$i} {
-      @include sb-grid-item(#{$i});
-    }
-  }
+// Extra small grid
+@include make-grid(xs);
 
-  @media (min-width: $sb-breakpoint-l) {
-    .#{$ns}col-l-#{$i} {
-      @include sb-grid-item(#{$i});
-    }
+// Small grid
+@media (min-width: $sb-breakpoint-s) {
+  @include make-grid(s);
+}
+
+// Makes `sb-col-#{i}` will behave like `sb-col-m-#{i}` for backwards compatibility
+@for $i from 1 through $grid-columns {
+  .#{$ns}col-#{$i} {
+    @include make-m-column($i);
   }
+}
+
+// Medium grid
+@media (min-width: $sb-breakpoint-m) {
+  @include make-grid(m);
+}
+
+// Large grid
+@media (min-width: $sb-breakpoint-l) {
+  @include make-grid(l);
 }
 
 // Push
@@ -183,25 +201,26 @@ $gutter-width: sb-px2rems(20px);
 //
 // Markup:
 // <div class="sb-grid">
-//   <div class="sb-tile sb-padding sb-col-5 sb-push-7">
-//     .sb-col-5 .sb-push-7
+//   <div class="sb-tile sb-col-4">
+//     .sb-col-4
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-8 sb-push-4">
-//     .sb-col-8 .sb-push-4
+//   <div class="sb-tile sb-col-3 sb-push-5">
+//     .sb-col-3 .sb-push-5
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-4 sb-push-2">
-//     .sb-col-4 .sb-push-2
+//   <div class="sb-tile sb-col-6">
+//     .sb-col-6
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-3 sb-push-3">
-//     .sb-col-3 .sb-push-3
+//   <div class="sb-tile sb-col-2 sb-push-2">
+//     .sb-col-2 .sb-push-2
 //   </div>
 // </div>
 //
 // Styleguide grid.push
 
+// Makes `sb-push-#{i}` will behave like `sb-col-m-push#{i}` for backwards compatibility
 @for $i from 1 through $grid-columns {
   .#{$ns}push-#{$i} {
-    margin-left: calc((100% / #{$grid-columns}) * #{$i} + (#{$gutter-width} / 2)) !important;
+    @include make-m-column-push($i);
   }
 }
 
@@ -211,24 +230,59 @@ $gutter-width: sb-px2rems(20px);
 //
 // Markup:
 // <div class="sb-grid">
-//   <div class="sb-tile sb-padding sb-col-4">
+//   <div class="sb-tile sb-col-4">
 //     .sb-col-4
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-10 sb-pull-2">
+//   <div class="sb-tile sb-col-8 sb-pull-1">
 //     .sb-col-10 .sb-pull-2
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-6">
+//   <div class="sb-tile sb-col-6">
 //     .sb-col-6
 //   </div>
-//   <div class="sb-tile sb-padding sb-col-6 sb-pull-4">
+//   <div class="sb-tile sb-col-6 sb-pull-4">
 //     .sb-col-6 .sb-pull-4
 //   </div>
 // </div>
 //
 // Styleguide grid.pull
 
+// Makes `sb-pull-#{i}` will behave like `sb-col-m-pull-#{i}` for backwards compatibility
 @for $i from 1 through $grid-columns {
   .#{$ns}pull-#{$i} {
-    margin-left: calc((100% / #{$grid-columns}) * #{-$i} + (#{$gutter-width} / 2)) !important;
+    @include make-m-column-pull($i);
   }
 }
+
+// Push / Pull
+//
+// The `sb-col-{size}-push-{i}` and `sb-col-{size}-pull-{i}` classes can be used to push or pull a column.
+// It can be used to change the order of our built-in grid columns, as shown in example.
+//
+// Markup:
+// <div class="sb-grid">
+//   <div class="sb-tile sb-col-m-9 sb-col-m-push-3">.sb-col-m-9 .sb-col-m-push-3</div>
+//   <div class="sb-tile sb-col-m-3 sb-col-m-pull-9">.sb-col-m-3 .sb-col-m-pull-9</div>
+// </div>
+//
+// Styleguide grid.pushpull
+
+// Nesting
+//
+// To nest your content with the default grid, add a new `.sb-grid` and set of `.col-m-*` columns within an existing `.col-m-* column.
+//
+// Markup:
+// <div class="sb-grid">
+//   <div class="sb-tile sb-col-m-9">
+//     Level 1: .sb-col-m-9
+//     <div class="sb-grid">
+//       <div class="sb-tile sb-col-s-8 sb-col-m-6">
+//         Level 2: .sb-col-s-8 .sb-col-m-6
+//       </div>
+//       <div class="sb-tile sb-col-s-4 sb-col-m-6">
+//         Level 2: .sb-col-s-4 .sb-col-m-6
+//       </div>
+//     </div>
+//   </div>
+// </div>
+//
+// Styleguide grid.nesting

--- a/src/settings/_responsive.scss
+++ b/src/settings/_responsive.scss
@@ -1,10 +1,18 @@
-$sb-container: 1920px;
-$sb-breakpoint-s: 480px;
-$sb-breakpoint-l: 960px;
+// Media queries breakpoints
+$sb-breakpoint-xs: 320px !default;
+$sb-breakpoint-s: 480px !default;
+$sb-breakpoint-m: 960px !default;
+$sb-breakpoint-l: 1200px !default;
 
 //Mobile first responsive mixins
 @mixin breakpoint-s() {
   @media (min-width: $sb-breakpoint-s) {
+    @content;
+  }
+}
+
+@mixin breakpoint-m() {
+  @media (min-width: $sb-breakpoint-m) {
     @content;
   }
 }

--- a/src/tools/_functions.scss
+++ b/src/tools/_functions.scss
@@ -18,3 +18,217 @@
     clear: both;
   }
 }
+
+// Grid functions from Bootstrap Sass https://github.com/twbs/bootstrap-sass
+
+// Centered container element
+@mixin container-fixed($gutter: $grid-gutter-width) {
+  @include sb-clearfix;
+
+  margin-right: auto;
+  margin-left: auto;
+  padding-left: floor(($gutter / 2));
+  padding-right: ceil(($gutter / 2));
+}
+
+// Creates a wrapper for a series of columns
+@mixin make-row($gutter: $grid-gutter-width) {
+  @include sb-clearfix;
+
+  margin-left: ceil(($gutter / -2));
+  margin-right: floor(($gutter / -2));
+}
+
+// Generate the extra small columns
+@mixin make-xs-column($columns, $gutter: $grid-gutter-width) {
+  position: relative;
+  float: left;
+  width: percentage(($columns / $grid-columns));
+  min-height: 1px;
+  padding-left: ($gutter / 2);
+  padding-right: ($gutter / 2);
+}
+
+@mixin make-xs-column-offset($columns) {
+  margin-left: percentage(($columns / $grid-columns));
+}
+
+@mixin make-xs-column-push($columns) {
+  left: percentage(($columns / $grid-columns));
+}
+
+@mixin make-xs-column-pull($columns) {
+  right: percentage(($columns / $grid-columns));
+}
+
+// Generate the small columns
+@mixin make-s-column($columns, $gutter: $grid-gutter-width) {
+  position: relative;
+  min-height: 1px;
+  padding-left: ($gutter / 2);
+  padding-right: ($gutter / 2);
+
+  @media (min-width: $sb-breakpoint-s) {
+    float: left;
+    width: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-s-column-offset($columns) {
+  @media (min-width: $sb-breakpoint-s) {
+    margin-left: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-s-column-push($columns) {
+  @media (min-width: $sb-breakpoint-s) {
+    left: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-s-column-pull($columns) {
+  @media (min-width: $sb-breakpoint-s) {
+    right: percentage(($columns / $grid-columns));
+  }
+}
+
+// Generate the medium columns
+@mixin make-m-column($columns, $gutter: $grid-gutter-width) {
+  position: relative;
+  min-height: 1px;
+  padding-left: ($gutter / 2);
+  padding-right: ($gutter / 2);
+
+  @media (min-width: $sb-breakpoint-m) {
+    float: left;
+    width: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-m-column-offset($columns) {
+  @media (min-width: $sb-breakpoint-m) {
+    margin-left: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-m-column-push($columns) {
+  @media (min-width: $sb-breakpoint-m) {
+    left: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-m-column-pull($columns) {
+  @media (min-width: $sb-breakpoint-m) {
+    right: percentage(($columns / $grid-columns));
+  }
+}
+
+// Generate the large columns
+@mixin make-l-column($columns, $gutter: $grid-gutter-width) {
+  position: relative;
+  min-height: 1px;
+  padding-left: ($gutter / 2);
+  padding-right: ($gutter / 2);
+
+  @media (min-width: $sb-breakpoint-l) {
+    float: left;
+    width: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-l-column-offset($columns) {
+  @media (min-width: $sb-breakpoint-l) {
+    margin-left: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-l-column-push($columns) {
+  @media (min-width: $sb-breakpoint-l) {
+    left: percentage(($columns / $grid-columns));
+  }
+}
+
+@mixin make-l-column-pull($columns) {
+  @media (min-width: $sb-breakpoint-l) {
+    right: percentage(($columns / $grid-columns));
+  }
+}
+
+// Other grid functions
+@mixin float-grid-columns($class, $i: 1, $list: '.sb-col-#{$class}-#{$i}') {
+  @for $i from (1 + 1) through $grid-columns {
+    $list: '#{$list}, .sb-col-#{$class}-#{$i}';
+  }
+
+  #{$list} {
+    float: left;
+  }
+}
+
+@mixin calc-grid-column($index, $class, $type) {
+  @if ($type == width) and ($index > 0) {
+    .sb-col-#{$class}-#{$index} {
+      width: percentage(($index / $grid-columns));
+    }
+  }
+
+  @if ($type == push) and ($index > 0) {
+    .sb-col-#{$class}-push-#{$index} {
+      left: percentage(($index / $grid-columns));
+    }
+  }
+
+  @if ($type == push) and ($index == 0) {
+    .sb-col-#{$class}-push-0 {
+      left: auto;
+    }
+  }
+
+  @if ($type == pull) and ($index > 0) {
+    .sb-col-#{$class}-pull-#{$index} {
+      right: percentage(($index / $grid-columns));
+    }
+  }
+
+  @if ($type == pull) and ($index == 0) {
+    .sb-col-#{$class}-pull-0 {
+      right: auto;
+    }
+  }
+
+  @if ($type == offset) {
+    .sb-col-#{$class}-offset-#{$index} {
+      margin-left: percentage(($index / $grid-columns));
+    }
+  }
+}
+
+@mixin loop-grid-columns($columns, $class, $type) {
+  @for $i from 0 through $columns {
+    @include calc-grid-column($i, $class, $type);
+  }
+}
+
+@mixin make-grid-columns($i: 1, $list: '.sb-col-xs-#{$i}, .sb-col-s-#{$i}, .sb-col-m-#{$i}, .sb-col-l-#{$i}') {
+  @for $i from (1 + 1) through $grid-columns {
+    $list: '#{$list}, .sb-col-xs-#{$i}, .sb-col-s-#{$i}, .sb-col-m-#{$i}, .sb-col-l-#{$i}';
+  }
+
+  #{$list} {
+    position: relative;
+    // Prevent columns from collapsing when empty
+    min-height: 1px;
+    // Inner gutter via padding
+    padding-left: ceil(($grid-gutter-width / 2));
+    padding-right: floor(($grid-gutter-width / 2));
+  }
+}
+
+// Create grid for specific class
+@mixin make-grid($class) {
+  @include float-grid-columns($class);
+  @include loop-grid-columns($grid-columns, $class, width);
+  @include loop-grid-columns($grid-columns, $class, pull);
+  @include loop-grid-columns($grid-columns, $class, push);
+  @include loop-grid-columns($grid-columns, $class, offset);
+}


### PR DESCRIPTION
BREAKING CHANGE
- Grid cells won't have top and bottom margins on tiles (these can be added with margin classes instead)
- Pull / push will behave differently, since it is now using left/right properties instead of margin-left/margin-right

## Changelog
- Gutter is now 23px to be consistent with the design space ratios.
- Class `.sb-grid` now removes first and last margins (similar to Bootstrap's row class)
- Added classes that allow for different columns at different breakpoints
- Allows nesting