### PR TITLE
fix(upload): remove outline from readonly input

### DIFF
--- a/src/components/_upload.scss
+++ b/src/components/_upload.scss
@@ -42,6 +42,7 @@
     border: 0;
     padding: 0;
     flex-grow: 2;
+    outline: none;
   }
 
   &__link {


### PR DESCRIPTION
Reviewers: @dine @keepitterron @pietvanzoen @beerecca @endritbajo @spirosikmd @katia @kdabo @NurahSadek 

For some reason this isn't an issue when rendering in stylabilla but is
an issue when rendering in react-styabilla.

*Before*
![awpx6](https://user-images.githubusercontent.com/630334/30900736-6082dea6-a365-11e7-9aa2-e3a16284c1fb.png)

*After*
![onk9f](https://user-images.githubusercontent.com/630334/30900741-65ebbc64-a365-11e7-9c05-5e36fe98dba2.png)
