### PR TITLE
feat(validation): Apply general form control validation

### DIFF
--- a/src/components/_form-control.scss
+++ b/src/components/_form-control.scss
@@ -23,13 +23,14 @@
   &__validation {
     display: none;
     margin-top: sb-px2rems(7px);
+    font-family: $sb-base-font-family;
     font-size: sb-px2rems(13px);
-    color: $sb-color-red-1;
+    color: $sb-color-red-2;
   }
 
   &--invalid {
     .#{$ns}input {
-      border: 1px solid $sb-color-red-1;
+      border: 1px solid $sb-color-red-2;
     }
   }
 

--- a/src/components/_form-control.scss
+++ b/src/components/_form-control.scss
@@ -11,18 +11,11 @@
 //   <label class="sb-label" for="text-form-input-id-{{modifier_class}}">Input Label</label>
 //   <div class="sb-form-control__input">
 //     <input class="sb-input" type="text" id="text-form-input-id-{{modifier_class}}" placeholder="Placeholder Text">
-//     <svg class="sb-icon sb-icon--error" viewBox="0 0 16 16">
-//       <path d="M6.17647059,7 L3.5,9.67647059 L4.32352941,10.5 L7,7.82352941 L9.67647059,10.5 L10.5,9.67647059 L7.82352941,7 L10.5,4.32352941 L9.67647059,3.5 L7,6.17647059 L4.32352941,3.5 L3.5,4.32352941 L6.17647059,7 Z M7,0 C10.8661875,0 14,3.1338125 14,7 C14,10.8661875 10.8661875,14 7,14 C3.1338125,14 0,10.8661875 0,7 C0,3.1338125 3.1338125,0 7,0 Z"></path>
-//     </svg>
-//     <svg class="sb-icon sb-icon--success" viewBox="0 0 16 16">
-//       <path d="M7,0 C3.1338125,0 0,3.1338125 0,7 C0,10.8661875 3.1338125,14 7,14 C10.8661875,14 14,10.8661875 14,7 C14,3.1338125 10.8661875,0 7,0 M5.57852066,10.5 L2.625,6.82666099 L3.93391119,5.5225724 L5.57896647,7.51873935 L10.733473,3.5 L11.375,4.11158433 L5.57852066,10.5"></path>
-//     </svg>
 //   </div>
 //   <p role="alert" class="sb-form-control__validation">Error message here.</p>
 // </div>
 //
 // .sb-form-control--invalid - invalid input
-// .sb-form-control--success - success input
 //
 // Styleguide Components.form
 
@@ -34,47 +27,13 @@
     color: $sb-color-red-1;
   }
 
-  .#{$ns}icon--error,
-  .#{$ns}icon--success {
-    display: none;
-  }
-
-  &--success {
-    .#{$ns}icon--success {
-      display: inline;
-    }
-
-    .#{$ns}input {
-      padding-right: sb-px2rems(30px);
-    }
-  }
-
   &--invalid {
-    .#{$ns}icon--error {
-      display: inline;
-    }
-
     .#{$ns}input {
-      padding-right: sb-px2rems(30px);
+      border: 1px solid $sb-color-red-1;
     }
   }
 
   &--invalid &__validation {
     display: block;
-  }
-
-  &__input {
-    position: relative;
-
-    .#{$ns}icon {
-      position: absolute;
-      top: 50%;
-      right: sb-px2rems(7px);
-      transform: translateY(-50%);
-    }
-
-    .#{$ns}input:disabled ~ .#{$ns}icon {
-      fill: $sb-color-light-3;
-    }
   }
 }


### PR DESCRIPTION
General style validation for the form control. `react-stylabilla` is already good to go, we just have to update the stylabilla version once this is published.

- `--invalid` applies a red border and a red validation message
- `--valid` has been removed
- radio, rating/nps, checkboxes only get a red error message

**THIS IS THE UPDATED VERSION**
<img width="604" alt="screen shot 2017-12-19 at 17 39 40" src="https://user-images.githubusercontent.com/593897/34167994-99b0f932-e4e3-11e7-848a-e5f78e324584.png">

**wrong version of red and wrong font, updated in this PR, still here for reference.**
input/textarea
<img width="627" alt="screen shot 2017-12-19 at 15 45 31" src="https://user-images.githubusercontent.com/593897/34165312-30838dc8-e4dc-11e7-8aec-eb289650620f.png">

upload
<img width="645" alt="screen shot 2017-12-19 at 15 46 03" src="https://user-images.githubusercontent.com/593897/34165310-3046c456-e4dc-11e7-9a8a-0e8678902493.png">

select/dropdown
<img width="629" alt="screen shot 2017-12-19 at 15 45 46" src="https://user-images.githubusercontent.com/593897/34165311-3065a7ae-e4dc-11e7-8112-423224a26648.png">

Close [MALL-499](https://usabilla.atlassian.net/browse/MALL-499)
Reviewers @usabilla/mallard @galagmon